### PR TITLE
Gh #9 add export png functionality to labelstudio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@overviewai/label-studio",
-  "version": "1.0.1-499-g8991c5d",
+  "version": "1.0.1-503-g22c7286",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@overviewai/label-studio",
-      "version": "1.0.1-499-g8991c5d",
+      "version": "1.0.1-503-g22c7286",
       "license": "Apache-2.0",
       "dependencies": {
         "@thi.ng/rle-pack": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overviewai/label-studio",
-  "version": "1.0.1-499-g8991c5d",
+  "version": "1.0.1-503-g22c7286",
   "description": "Data Labeling Tool that is backend agnostic and can be embedded into your applications",
   "author": "Overview.ai (https://github.com/OverviewCorporation)",
   "license": "Apache-2.0",

--- a/src/mixins/Regions.js
+++ b/src/mixins/Regions.js
@@ -309,6 +309,9 @@ const RegionsMixin = types
           self.origin = 'prediction-changed';
         }
 
+
+        self.annotation.updateDataUrl(self.parent?.stageRef?.toDataURL());
+
         // everything above is related to dynamic preannotations
         if (!self.dynamic || self.fromSuggestion) return;
 

--- a/src/stores/AnnotationStore.js
+++ b/src/stores/AnnotationStore.js
@@ -38,6 +38,8 @@ const Annotation = types
       ), null,
     ),
 
+    dataUrl: types.maybeNull(types.string),
+
     createdDate: types.optional(types.string, Utils.UDate.currentISODate()),
     createdAgo: types.maybeNull(types.string),
     createdBy: types.optional(types.string, "Admin"),
@@ -993,6 +995,10 @@ const Annotation = types
       self.regions.forEach(r => {
         r.dynamic && r.deleteRegion();
       });
+    },
+
+    updateDataUrl(url) {
+      self.dataUrl = url;
     },
 
     acceptSuggestion(id) {


### PR DESCRIPTION

This PR does two things
- Adds `dataUrl` to the `Annotation` object. When clicking submit, LS will pass the Annotation object to through its API. The Caller now has the DataURL of the Annotation and can generate a PNG
- On `notifiyFinishedDrawing` update the `dataUrl` object on Annotation this way the canvas is always in sync with the data url